### PR TITLE
Use metadata cache to read the frontmatter of a file, no need to pars…

### DIFF
--- a/builders/HabitBuilder.ts
+++ b/builders/HabitBuilder.ts
@@ -1,14 +1,11 @@
 import Habit from "models/Habit";
 import Entry, { type Status } from "models/Entry";
 import DateValue from "models/DateValue";
-import { parseYaml, TFile } from "obsidian";
+import { TFile, type FrontMatterCache } from "obsidian";
 
 // * haha get it? habit builder, cool!
 export const HabitBuilder = {
-	fromFile(file: TFile, data: string): Habit {
-		// Extract Frontmatter to a Value Object
-		const frontmatter = data.split('---')[1];
-
+	fromFile(file: TFile, frontmatter: FrontMatterCache | undefined): Habit {
 		const habitId = file.basename;
 		const name = file.basename.replaceAll('-', " ");
 		const habitPath = file.path;
@@ -16,11 +13,8 @@ export const HabitBuilder = {
 		// If the Habit file has no frontmatter, return empty Entries array 
 		if (!frontmatter) return new Habit({ id: habitId, name, path: habitPath, entries: [] })
 
-		// TODO: Handle parsing yaml errors
-		const rawEntryData = parseYaml(frontmatter);
-
 		const entries = Array.from(
-			Object.entries(rawEntryData),
+			Object.entries(frontmatter),
 			([date, status]) =>
 				DateValue.validate(date)
 					? new Entry({ habitId, habitPath, date: new DateValue(date), status: status as Status })

--- a/components/icons/Icon.svelte
+++ b/components/icons/Icon.svelte
@@ -10,10 +10,10 @@
 
   	return {
   		update(newIcon: typeof icon) {
-  			node.innerHTML = "";
+  			node.empty();
   			if (newIcon) setIcon(node, newIcon);
   		},
-  		destroy() { node.innerHTML = "" }
+  		destroy() { node.empty() }
   	};
   }
 </script>

--- a/main.ts
+++ b/main.ts
@@ -11,7 +11,7 @@ export default class TinyHabitsPlugin extends Plugin {
 	private settings: { folderPath: string, displayName: string | undefined }
 
 	async onload() {
-		this.habitRepository = new HabitRepository(this.app.vault, this.app.fileManager)
+		this.habitRepository = new HabitRepository(this.app.vault, this.app.fileManager, this.app.metadataCache)
 
 		this.registerMarkdownCodeBlockProcessor(
 			'habits',
@@ -70,6 +70,9 @@ export default class TinyHabitsPlugin extends Plugin {
 		);
 		this.registerEvent(
 			this.app.vault.on("modify", (file) => this.refreshHabits(this.getFolderPath(file)))
+		);
+		this.registerEvent(
+			this.app.metadataCache.on('changed', (file) => this.refreshHabits(this.getFolderPath(file)))
 		);
 	}
 

--- a/repositories/HabitRepository.ts
+++ b/repositories/HabitRepository.ts
@@ -1,16 +1,18 @@
-import { FileManager, Notice, TFile, type Vault } from "obsidian";
+import { type FileManager, type MetadataCache, Notice, TFile, type Vault } from "obsidian";
 import type { THabitRepository } from '../types/THabitRepository';
 import Habit from "models/Habit";
 import Entry from "models/Entry";
 import { HabitBuilder }  from "builders/HabitBuilder";
 
 class HabitRepository implements THabitRepository {
+	private readonly metadataCache
 	private readonly vault
 	private readonly fileManager
 
-	constructor(vault: Vault, fileManager: FileManager) {
+	constructor(vault: Vault, fileManager: FileManager, metadataCache: MetadataCache) {
 		this.vault = vault
 		this.fileManager = fileManager
+		this.metadataCache = metadataCache
 	}
 
 	async allHabits(folderPath: string) {
@@ -33,8 +35,8 @@ class HabitRepository implements THabitRepository {
 
 	async buildHabits(file: TFile) {
 		try {
-			const data = await this.vault.read(file);
-			return HabitBuilder.fromFile(file, data);
+			const frontmatter = this.metadataCache.getFileCache(file)?.frontmatter;
+			return HabitBuilder.fromFile(file, frontmatter);
 		}
 		catch (error) {
 			console.warn(`Failed to build habits for ${file.basename}:`, error);


### PR DESCRIPTION
…e the string as yaml anymore. Prefer node.empty() over node.innerHtml = "" for better performance.